### PR TITLE
fix: drop replacesStatements from BODS mapper (removed in BODS 0.4)

### DIFF
--- a/backend/opencheck/bods/mapper.py
+++ b/backend/opencheck/bods/mapper.py
@@ -369,39 +369,34 @@ def make_relationship_statement(
     source_url: str | None = None,
     publication_date: str | None = None,
     record_status: str = "new",
-    replaces_statements: Iterable[str] | None = None,
 ) -> dict[str, Any]:
     """Build a BODS v0.4 relationship statement.
 
-    Lifecycle (BODS *Information updates* + *Record identifiers* modelling
+    Lifecycle (BODS 0.4 *Information updates* + *Record identifiers* modelling
     requirements):
 
     * The ``recordId`` of a relationship MUST be **stable over time** — every
       statement in the record's lifecycle (``new`` → ``updated`` → ``closed``)
       shares the same ``recordId``. It is derived purely from ``local_id`` here,
-      so it never changes as the relationship's status changes.
+      so it never changes as the relationship's status changes. Consumers link a
+      record's versions together through this shared ``recordId``.
     * Each ``statementId`` MUST be unique. For non-``new`` lifecycle stages the
       statementId is varied (by status + publication date) so the closed/updated
       statement is a distinct statement from the original ``new`` one, while the
       ``recordId`` stays put.
-    * A non-``new`` statement automatically records ``replacesStatements``
-      pointing at the original ``new`` statement's id (unless the caller supplies
-      an explicit list), making the supersession explicit. Deterministic ids mean
-      this link needs no stored history.
+
+    BODS 0.4 **removed** the ``replacesStatements`` field (see the 0.4.0
+    changelog "Removed" section): supersession is expressed solely through the
+    shared, stable ``recordId``, so this factory does not emit
+    ``replacesStatements``.
     """
     record_id = _stable_id(source_id, "relationship-record", local_id)
     if record_status == "new":
         statement_id = _stable_id(source_id, "relationship", local_id)
-        replaced: list[str] | None = list(replaces_statements) if replaces_statements else None
     else:
         statement_id = _stable_id(
             source_id, "relationship", local_id, record_status, publication_date or ""
         )
-        if replaces_statements is not None:
-            replaced = list(replaces_statements)
-        else:
-            # Supersede the original 'new' statement for this same recordId.
-            replaced = [_stable_id(source_id, "relationship", local_id)]
 
     statement: dict[str, Any] = {
         "statementId": statement_id,
@@ -423,8 +418,6 @@ def make_relationship_statement(
         },
         "source": _source_block(source_id, source_url),
     }
-    if replaced:
-        statement["replacesStatements"] = replaced
     return statement
 
 
@@ -961,8 +954,9 @@ def _emit_company_statements(
                 interest["beneficialOwnershipOrControl"] = False
 
         # A ceased PSC closes the relationship: stamp each interest with the
-        # cessation date and emit the statement with recordStatus 'closed'
-        # (which auto-records replacesStatements -> the original 'new').
+        # cessation date and emit the statement with recordStatus 'closed'. The
+        # closed statement shares the original's stable recordId — which is how
+        # BODS 0.4 links a record's versions (replacesStatements was removed).
         if ceased_on:
             for interest in interests:
                 interest["endDate"] = ceased_on

--- a/backend/scripts/map_psc_stream.py
+++ b/backend/scripts/map_psc_stream.py
@@ -274,7 +274,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     if closed:
         print(f"  NOTE : {closed} cessation event(s) emitted as BODS 'closed' records")
-        print("         (recordStatus=closed, interest.endDate, replacesStatements).")
+        print("         (recordStatus=closed, interest.endDate, shared recordId).")
     deleted = outcome.get("skipped: deleted / no data block", 0)
     if deleted:
         print(f"  NOTE : {deleted} 'deleted' event(s) carry no data — the live service")

--- a/backend/tests/test_bods_mapper.py
+++ b/backend/tests/test_bods_mapper.py
@@ -287,9 +287,10 @@ def test_ceased_pscs_emit_closed_record() -> None:
     closed = [r for r in rels if r["recordStatus"] == "closed"]
     assert len(closed) == 1
     c = closed[0]
-    # Stable recordId vs distinct statementId; supersedes the original 'new'.
+    # Stable recordId vs distinct statementId. BODS 0.4 links a record's versions
+    # via the shared recordId; the removed replacesStatements field must NOT appear.
     assert c["recordId"] != c["statementId"]
-    assert c["replacesStatements"], "closed record must record what it replaces"
+    assert "replacesStatements" not in c, "replacesStatements was removed in BODS 0.4"
     # Cessation date stamped on every interest and on the publication date.
     assert all(
         i.get("endDate") == "2024-01-01" for i in c["recordDetails"]["interests"]
@@ -298,8 +299,9 @@ def test_ceased_pscs_emit_closed_record() -> None:
 
 
 def test_relationship_recordid_stable_across_lifecycle() -> None:
-    """recordId is stable across new->closed; statementId is distinct;
-    replacesStatements links the closed statement to the original 'new'."""
+    """recordId is stable across new->closed; statementId is distinct. BODS 0.4
+    links a record's versions via the shared recordId — the removed
+    replacesStatements field must not be emitted on any statement."""
     common = dict(
         source_id="companies_house",
         local_id="00102498:psc:abc",
@@ -321,8 +323,8 @@ def test_relationship_recordid_stable_across_lifecycle() -> None:
     assert new["statementId"] != closed["statementId"]  # each statement unique
     assert new["recordStatus"] == "new"
     assert closed["recordStatus"] == "closed"
-    assert closed["replacesStatements"] == [new["statementId"]]
     assert "replacesStatements" not in new
+    assert "replacesStatements" not in closed
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
make_relationship_statement no longer emits the 0.4-removed replacesStatements field; a record's versions link via the shared, stable recordId. Update the lifecycle tests to assert its absence and fix a note in map_psc_stream.py.