### PR TITLE
feat(reconcile): name-only POSSIBLY_SAME_AS entity matching (human-re…

### DIFF
--- a/backend/opencheck/reconcile.py
+++ b/backend/opencheck/reconcile.py
@@ -151,3 +151,119 @@ def _normalise_name(name: str) -> str:
     ascii_only = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
     cleaned = re.sub(r"[^\w\s]", " ", ascii_only.lower())
     return re.sub(r"\s+", " ", cleaned).strip()
+
+
+# ---------------------------------------------------------------------
+# POSSIBLY_SAME_AS — name-only "likely same" entity candidates.
+#
+# Operates on the assembled BODS bundle (entity statements carry name +
+# jurisdiction + foundingDate, which SourceHits do not). Surfaces the residual
+# the identifier bridges above can't: distinct entity statements that share an
+# exact normalised name + jurisdiction but no shared identifier. The Splink
+# spike (Notion) showed this rule beats fuzzy matching and a trained
+# probabilistic model on OpenCheck's data (F1 0.95). These are **suggestions
+# for a human** (rendered as a dashed "likely same" edge), never a silent merge.
+# A founding-date tiebreaker rejects the same-name/different-entity case (e.g.
+# distinct same-named subsidiaries incorporated in different years); address is
+# deliberately not used — cross-source formatting is too noisy to require.
+#
+# Mirror of frontend ``possiblySameAs`` in ``frontend/src/lib/reconcile.ts`` —
+# keep the two in sync.
+# ---------------------------------------------------------------------
+
+
+@dataclass
+class PossiblySame:
+    """A name-only 'likely same' candidate between two entity statements."""
+
+    a: str  # statementId
+    b: str  # statementId
+    reason: str
+
+    def to_dict(self) -> dict:
+        return {"a": self.a, "b": self.b, "reason": self.reason}
+
+
+_LEI_RE = re.compile(r"^[0-9A-Z]{18}[0-9]{2}$")
+
+
+def _entity_jurisdiction(rd: dict) -> str:
+    # GLEIF entity statements use `incorporatedInJurisdiction`; OpenSanctions
+    # (and some others) use `jurisdiction`. Read both.
+    jur = rd.get("jurisdiction") or rd.get("incorporatedInJurisdiction") or {}
+    code = jur.get("code") if isinstance(jur, dict) else ""
+    return str(code or "").strip().upper().split("-")[0]
+
+
+def _identifier_keys(stmt: dict) -> set[str]:
+    """Identifier-merge keys for an entity (mirror of frontend ``identKeys``):
+    LEI (scheme-agnostic) + scheme-scoped values + a jurisdiction-scoped key for
+    bare national registration numbers (VAT excluded — see frontend note). Two
+    statements that share any key are already linked by identifier, so they are
+    NOT name-only candidates."""
+    rd = stmt.get("recordDetails") or {}
+    jur = _entity_jurisdiction(rd)
+    keys: set[str] = set()
+    for i in rd.get("identifiers") or []:
+        val = str(i.get("id") or "").strip().upper()
+        if not val:
+            continue
+        if _LEI_RE.match(val):
+            keys.add(f"LEI:{val}")
+            continue
+        scheme = str(i.get("scheme") or "?").strip().upper()
+        keys.add(f"{scheme}:{val}")
+        if jur and (scheme == "" or scheme.startswith(f"{jur}-")) and "VAT" not in scheme and "/" not in val:
+            keys.add(f"JUR:{jur}:{val}")
+    return keys
+
+
+def _founding_year(stmt: dict) -> str | None:
+    rd = stmt.get("recordDetails") or {}
+    m = re.match(r"(\d{4})", str(rd.get("foundingDate") or ""))
+    return m.group(1) if m else None
+
+
+def _founding_compatible(a: dict, b: dict) -> bool:
+    """Compatible unless BOTH founding years are present and differ."""
+    ya, yb = _founding_year(a), _founding_year(b)
+    return not (ya and yb and ya != yb)
+
+
+def possibly_same_entities(bods: list[dict]) -> list[PossiblySame]:
+    """Candidate 'likely same' entity pairs: exact normalised name + jurisdiction,
+    passing the founding-date tiebreaker. Run on the assembled BODS bundle."""
+    ents = [s for s in (bods or []) if s.get("recordType") == "entity" and s.get("statementId")]
+    id_keys = {s["statementId"]: _identifier_keys(s) for s in ents}
+    groups: dict[tuple[str, str], list[dict]] = {}
+    for s in ents:
+        rd = s.get("recordDetails") or {}
+        nm = _normalise_name(rd.get("name") or "")
+        jur = _entity_jurisdiction(rd)
+        if not nm or not jur:  # both required — name alone over-merges
+            continue
+        groups.setdefault((nm, jur), []).append(s)
+
+    out: list[PossiblySame] = []
+    seen: set[tuple[str, str]] = set()
+    for group in groups.values():
+        if len(group) < 2:
+            continue
+        for i in range(len(group)):
+            for j in range(i + 1, len(group)):
+                a, b = group[i], group[j]
+                if a["statementId"] == b["statementId"]:
+                    continue
+                # Skip pairs already linked by a shared identifier — they are
+                # known-same (the bundle just isn't identifier-merged here),
+                # not the name-only residual this surfaces.
+                if id_keys[a["statementId"]] & id_keys[b["statementId"]]:
+                    continue
+                if not _founding_compatible(a, b):
+                    continue
+                pair = tuple(sorted((a["statementId"], b["statementId"])))
+                if pair in seen:
+                    continue
+                seen.add(pair)
+                out.append(PossiblySame(pair[0], pair[1], "same name + jurisdiction"))
+    return out

--- a/backend/opencheck/routers/lookup.py
+++ b/backend/opencheck/routers/lookup.py
@@ -20,7 +20,7 @@ from ..sources.base import LookupDeriver, raw_redaction_notice
 from .. import bods_data
 from ..cross_check import assess_cross_source_names
 from ..icij_check import assess_icij_names
-from ..reconcile import reconcile
+from ..reconcile import possibly_same_entities, reconcile
 from ..risk import RiskSignal, assess_bundle, assess_hits
 from ..sources import REGISTRY, SearchKind, SourceHit, SourceInfo
 from ..sources.schemas import SourceSchemaError
@@ -81,6 +81,9 @@ class ReportResponse(BaseModel):
     bods: list[dict[str, Any]]
     bods_issues: list[str]
     license_notices: list[dict[str, str]]
+    #: Name-only "likely same" entity candidates (same name + jurisdiction, no
+    #: shared identifier) — human-review suggestions, never auto-merges.
+    possibly_same_entities: list[dict[str, Any]] = []
 
 
 class LookupResponse(ReportResponse):
@@ -221,6 +224,7 @@ async def _build_report(
         bods=bods_all,
         bods_issues=bods_issues,
         license_notices=license_notices,
+        possibly_same_entities=[p.to_dict() for p in possibly_same_entities(bods_all)],
     )
 
 
@@ -1419,6 +1423,7 @@ async def lookup(
         bods=bods_all,
         bods_issues=bods_issues,
         license_notices=license_notices,
+        possibly_same_entities=[p.to_dict() for p in possibly_same_entities(bods_all)],
         lei=norm_lei,
         legal_name=legal_name,
         jurisdiction=jurisdiction,

--- a/backend/tests/test_reconcile.py
+++ b/backend/tests/test_reconcile.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from opencheck.reconcile import reconcile
+from opencheck.reconcile import possibly_same_entities, reconcile
 from opencheck.sources import SearchKind, SourceHit
 
 
@@ -223,3 +223,78 @@ def test_reconcile_dict_serialisation() -> None:
     assert payload["confidence"] == "strong"
     assert payload["key"] == "lei"
     assert {h["source_id"] for h in payload["hits"]} == {"gleif", "opensanctions"}
+
+
+# ---------------------------------------------------------------------
+# POSSIBLY_SAME_AS — name-only entity candidates (Splink-spike outcome)
+# ---------------------------------------------------------------------
+
+
+def _ent(sid: str, name: str, jur: str, date: str | None = None, *, jur_key: str = "jurisdiction") -> dict:
+    rd: dict = {"name": name, jur_key: {"code": jur}, "identifiers": []}
+    if date:
+        rd["foundingDate"] = date
+    return {"statementId": sid, "recordType": "entity", "recordDetails": rd}
+
+
+def test_possibly_same_flags_name_plus_jurisdiction() -> None:
+    pairs = possibly_same_entities([
+        _ent("a", "Acme Ltd", "GB", "1990-01-01"),
+        _ent("b", "ACME LTD.", "GB", "1990-06-02"),
+    ])
+    assert len(pairs) == 1
+    assert {pairs[0].a, pairs[0].b} == {"a", "b"}
+    assert pairs[0].reason == "same name + jurisdiction"
+
+
+def test_possibly_same_respects_jurisdiction() -> None:
+    pairs = possibly_same_entities([
+        _ent("a", "Acme Ltd", "GB"),
+        _ent("b", "Acme Ltd", "US"),
+    ])
+    assert pairs == []
+
+
+def test_possibly_same_founding_date_tiebreaker() -> None:
+    pairs = possibly_same_entities([
+        _ent("a", "Acme Ltd", "GB", "1990-01-01"),
+        _ent("b", "Acme Ltd", "GB", "2005-01-01"),
+    ])
+    assert pairs == []  # different incorporation year -> different entity
+
+
+def test_possibly_same_missing_date_is_compatible() -> None:
+    pairs = possibly_same_entities([
+        _ent("a", "Acme Ltd", "GB", "1990"),
+        _ent("b", "Acme Ltd", "GB"),
+    ])
+    assert len(pairs) == 1
+
+
+def test_possibly_same_does_not_flag_alpha_vs_beta() -> None:
+    pairs = possibly_same_entities([
+        _ent("a", "BP Exploration (Alpha) Limited", "GB", "1990"),
+        _ent("b", "BP Exploration (Beta) Limited", "GB", "1990"),
+    ])
+    assert pairs == []
+
+
+def test_possibly_same_skips_identifier_linked_pairs() -> None:
+    # Share an LEI -> known same (identifier-linked), not a name-only candidate.
+    lei = "529900T8BM49AURSDO55"
+    a = {"statementId": "a", "recordType": "entity", "recordDetails": {
+        "name": "Acme Ltd", "jurisdiction": {"code": "GB"},
+        "identifiers": [{"scheme": "XI-LEI", "id": lei}]}}
+    b = {"statementId": "b", "recordType": "entity", "recordDetails": {
+        "name": "ACME LTD.", "jurisdiction": {"code": "GB"},
+        "identifiers": [{"scheme": "XI-LEI", "id": lei}]}}
+    assert possibly_same_entities([a, b]) == []
+
+
+def test_possibly_same_reads_incorporated_in_jurisdiction() -> None:
+    # GLEIF uses incorporatedInJurisdiction; OpenSanctions uses jurisdiction.
+    pairs = possibly_same_entities([
+        _ent("a", "Globex Holdings", "FR", "2001", jur_key="incorporatedInJurisdiction"),
+        _ent("b", "GLOBEX HOLDINGS", "FR", "2001", jur_key="jurisdiction"),
+    ])
+    assert len(pairs) == 1

--- a/frontend/src/components/BODSGraph.tsx
+++ b/frontend/src/components/BODSGraph.tsx
@@ -29,6 +29,7 @@ import {
   type Visibility,
 } from "../lib/bodsGraph";
 import type { RiskSignal } from "../lib/api";
+import type { SameAsCandidate } from "../lib/reconcile";
 
 cytoscape.use(dagre);
 
@@ -116,8 +117,9 @@ function buildSignalMap(signals: RiskSignal[]): Map<string, RiskSignal[]> {
 // BODS GraphModel → Cytoscape elements
 // ---------------------------------------------------------------------------
 
-function modelToElements(model: GraphModel): ElementDefinition[] {
+function modelToElements(model: GraphModel, sameAs: SameAsCandidate[] = []): ElementDefinition[] {
   const elements: ElementDefinition[] = [];
+  const nodeIds = new Set(model.nodes.map((n) => n.id));
   for (const n of model.nodes) {
     elements.push({
       data: { id: n.id, label: n.label, recordType: n.recordType, icon: n.icon, flagUrl: n.flagUrl, sources: n.sources },
@@ -128,6 +130,19 @@ function modelToElements(model: GraphModel): ElementDefinition[] {
       data: {
         id: e.id, source: e.source, target: e.target,
         label: e.label, category: e.category, details: e.details, sources: e.sources,
+      },
+    });
+  }
+  // POSSIBLY_SAME_AS — dashed, undirected "likely same" suggestion edges. Added
+  // here (not in the GraphModel) so they never enter the ownership hierarchy
+  // used by collapse/tree/frontier — they are a human-review overlay only.
+  for (const c of sameAs) {
+    if (!nodeIds.has(c.a) || !nodeIds.has(c.b)) continue;
+    elements.push({
+      data: {
+        id: `sameas~${c.a}~${c.b}`, source: c.a, target: c.b,
+        label: "likely same", category: "possiblySame", sources: [],
+        details: `Likely the same entity (${c.reason}, no shared identifier) — review before treating as one.`,
       },
     });
   }
@@ -210,6 +225,16 @@ const STYLESHEET: StylesheetStyle[] = [
   { selector: "edge[category = 'control']",  style: { "line-color": "#e65100", "target-arrow-color": "#e65100", color: "#e65100" } as cytoscape.Css.Edge },
   { selector: "edge[category = 'role']",     style: { "line-color": "#6a1b9a", "target-arrow-color": "#6a1b9a", color: "#6a1b9a", "line-style": "dashed" } as cytoscape.Css.Edge },
   { selector: "edge[category = 'unknown']",  style: { "line-color": "#888",    "target-arrow-color": "#888",    color: "#888" } as cytoscape.Css.Edge },
+  // POSSIBLY_SAME_AS — dashed, undirected, amber; a "likely same entity" suggestion for review (never a merge).
+  {
+    selector: "edge[category = 'possiblySame']",
+    style: {
+      "line-color": "#b45309", color: "#b45309",
+      "line-style": "dashed", "curve-style": "bezier",
+      "target-arrow-shape": "none", "source-arrow-shape": "none",
+      width: 1.5, "font-style": "italic",
+    } as cytoscape.Css.Edge,
+  },
   { selector: "edge.hovered",                style: { width: 3, "z-index": 999 } as cytoscape.Css.Edge },
 ];
 
@@ -232,6 +257,7 @@ export default function BODSGraph({
   selectedId = null,
   onSelect,
   highlightSource = null,
+  sameAs = [],
 }: {
   model: GraphModel;
   signals?: RiskSignal[];
@@ -245,6 +271,8 @@ export default function BODSGraph({
   /** FullCheck provenance: when set, nodes/edges asserted by this source are
    *  highlighted and the rest dimmed (highlight, don't hide). */
   highlightSource?: string | null;
+  /** FullCheck: name-only "likely same" candidates → dashed review edges. */
+  sameAs?: SameAsCandidate[];
 }) {
   const containerRef  = useRef<HTMLDivElement | null>(null);
   const cyRef         = useRef<Core | null>(null);
@@ -290,7 +318,7 @@ export default function BODSGraph({
 
     const cy = cytoscape({
       container: el,
-      elements: modelToElements(model),
+      elements: modelToElements(model, sameAs),
       style: STYLESHEET,
       layout: DAGRE_LAYOUT,
       userZoomingEnabled: true,
@@ -361,7 +389,7 @@ export default function BODSGraph({
 
     return () => { cy.destroy(); cyRef.current = null; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [model, signals]);
+  }, [model, signals, sameAs]);
 
   // ── Apply collapse: hide/show elements, re-layout the visible subset ───────
   useEffect(() => {

--- a/frontend/src/components/BodsGraphExplorer.tsx
+++ b/frontend/src/components/BodsGraphExplorer.tsx
@@ -36,7 +36,7 @@ import {
   signalsBeyond,
   type ExpandDirection,
 } from "../lib/expand";
-import { reconcileBods, remapSignals } from "../lib/reconcile";
+import { reconcileBods, remapSignals, possiblySameAs } from "../lib/reconcile";
 import { RiskChip } from "./risk/RiskChip";
 import { SourceLegend } from "./SourceLegend";
 
@@ -116,6 +116,9 @@ export default function BodsGraphExplorer({
     () => bodsToGraph((recon?.statements ?? allStatements) as Stmt[]),
     [recon, allStatements]
   );
+  // FullCheck: name-only "likely same" candidates (post-reconciliation) → dashed
+  // review edges. Empty for QuickCheck (recon === null).
+  const sameAs = useMemo(() => (recon ? possiblySameAs(recon.statements) : []), [recon]);
   // Frontier/expansion run on the RAW (unreconciled) edges so the live traversal
   // keys are unchanged; for QuickCheck raw == display.
   const rawEdges = useMemo(
@@ -177,10 +180,25 @@ export default function BodsGraphExplorer({
   }
 
   // ── "Add next layer" over the whole frontier (direction set by the view) ───
-  const frontier = useMemo(
-    () => frontierAnchors(allStatements, rawEdges, expandedIds, direction),
-    [allStatements, rawEdges, expandedIds, direction]
-  );
+  // The frontier is computed on the RAW statements (so the live traversal keys
+  // are unchanged). In FullCheck the display is reconciled, so a raw frontier
+  // can list several per-source duplicates of the same entity — inflating the
+  // "Add next layer — N" count above the visible node count and re-fetching the
+  // same company. Dedupe by canonical id (via the reconcile remap) so the count
+  // matches what the user sees and each entity is expanded once.
+  const frontier = useMemo(() => {
+    const raw = frontierAnchors(allStatements, rawEdges, expandedIds, direction);
+    if (!recon) return raw;
+    const seen = new Set<string>();
+    const deduped: typeof raw = [];
+    for (const f of raw) {
+      const cid = recon.remap[f.anchor] ?? f.anchor;
+      if (seen.has(cid)) continue;
+      seen.add(cid);
+      deduped.push(f);
+    }
+    return deduped;
+  }, [allStatements, rawEdges, expandedIds, direction, recon]);
   const noun = direction === "subsidiaries" ? "subsidiaries" : "owners/controllers";
   const helperText =
     direction === "subsidiaries"
@@ -449,6 +467,13 @@ export default function BodsGraphExplorer({
                 onToggle={(s) => setHighlightSource((cur) => (cur === s ? null : s))}
               />
             )}
+            {fullCheck && sameAs.length > 0 && (
+              <p className="mb-1.5 text-[11px] text-[#b45309] leading-[1.5]">
+                <span className="font-semibold">{sameAs.length}</span> dashed “likely same”{" "}
+                {sameAs.length === 1 ? "link" : "links"}: same name + jurisdiction, no shared
+                identifier — review before treating as one entity (not auto-merged).
+              </p>
+            )}
             <BODSGraph
               model={model}
               signals={displaySignals}
@@ -458,6 +483,7 @@ export default function BodsGraphExplorer({
               selectedId={selectedId}
               onSelect={setSelectedId}
               highlightSource={highlightSource}
+              sameAs={sameAs}
             />
           </div>
         )}

--- a/frontend/src/lib/bodsGraph.ts
+++ b/frontend/src/lib/bodsGraph.ts
@@ -36,7 +36,7 @@ export interface Interest {
   details?: string;
 }
 
-export type EdgeCategory = "ownership" | "control" | "role" | "unknown";
+export type EdgeCategory = "ownership" | "control" | "role" | "unknown" | "possiblySame";
 
 export interface GraphNode {
   id: string;

--- a/frontend/src/lib/reconcile.test.ts
+++ b/frontend/src/lib/reconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { reconcileBods, remapSignals } from "./reconcile";
+import { reconcileBods, remapSignals, possiblySameAs } from "./reconcile";
 import { bodsToGraph } from "./bodsGraph";
 import type { RiskSignal } from "./api";
 
@@ -156,6 +156,43 @@ describe("reconcileBods", () => {
     expect(entities[0]._sources).toEqual(expect.arrayContaining(["GLEIF", "CVR"]));
   });
 
+  it("merges on a shared VAT number (scheme-scoped), no LEI needed", () => {
+    const { statements } = reconcileBods([
+      {
+        statementId: "g", recordType: "entity",
+        recordDetails: { name: "Müller GmbH", jurisdiction: { code: "DE" },
+          identifiers: [{ scheme: "XI-VAT", id: "DE123456789" }] },
+        source: { description: "GLEIF" },
+      },
+      {
+        statementId: "o", recordType: "entity",
+        recordDetails: { name: "MULLER GMBH", jurisdiction: { code: "DE" },
+          identifiers: [{ scheme: "XI-VAT", id: "DE123456789" }] },
+        source: { description: "OpenCorporates" },
+      },
+    ]);
+    expect(statements.filter((s) => s.recordType === "entity")).toHaveLength(1);
+  });
+
+  it("does not merge a VAT number that collides with a company number (same jurisdiction)", () => {
+    // Coincidental bare-value collision across identifier TYPES must not merge.
+    const { statements } = reconcileBods([
+      {
+        statementId: "a", recordType: "entity",
+        recordDetails: { name: "Alpha A/S", jurisdiction: { code: "DK" },
+          identifiers: [{ scheme: "DK-CVR", id: "12345678" }] },
+        source: { description: "CVR" },
+      },
+      {
+        statementId: "b", recordType: "entity",
+        recordDetails: { name: "Beta A/S", jurisdiction: { code: "DK" },
+          identifiers: [{ scheme: "DK-VAT", id: "12345678" }] },
+        source: { description: "GLEIF" },
+      },
+    ]);
+    expect(statements.filter((s) => s.recordType === "entity")).toHaveLength(2);
+  });
+
   it("does not cross-merge same-value ids in different jurisdictions", () => {
     const { statements } = reconcileBods([
       {
@@ -202,5 +239,65 @@ describe("remapSignals", () => {
   it("is a no-op when there is nothing to remap", () => {
     const signals = [{ code: "PEP", evidence: {} }] as unknown as RiskSignal[];
     expect(remapSignals(signals, {})).toBe(signals);
+  });
+});
+
+describe("possiblySameAs", () => {
+  const ent = (id: string, name: string, jur: string, date?: string): Stmt => ({
+    statementId: id,
+    recordType: "entity",
+    recordDetails: {
+      name,
+      jurisdiction: { code: jur },
+      ...(date ? { foundingDate: date } : {}),
+      identifiers: [],
+    },
+  });
+
+  it("flags same normalised name + jurisdiction (no shared id)", () => {
+    const c = possiblySameAs([ent("a", "Acme Ltd", "GB", "1990-01-01"), ent("b", "ACME LTD.", "GB", "1990-06-02")]);
+    expect(c).toHaveLength(1);
+    expect([c[0].a, c[0].b].sort()).toEqual(["a", "b"]);
+  });
+
+  it("does not flag the same name in different jurisdictions", () => {
+    expect(possiblySameAs([ent("a", "Acme Ltd", "GB"), ent("b", "Acme Ltd", "US")])).toHaveLength(0);
+  });
+
+  it("does not flag distinct same-name entities incorporated in different years (tiebreaker)", () => {
+    expect(possiblySameAs([ent("a", "Acme Ltd", "GB", "1990-01-01"), ent("b", "Acme Ltd", "GB", "2005-01-01")])).toHaveLength(0);
+  });
+
+  it("treats a missing founding date as compatible", () => {
+    expect(possiblySameAs([ent("a", "Acme Ltd", "GB", "1990"), ent("b", "Acme Ltd", "GB")])).toHaveLength(1);
+  });
+
+  it("does not flag genuinely different names (Alpha vs Beta)", () => {
+    expect(possiblySameAs([
+      ent("a", "BP Exploration (Alpha) Limited", "GB", "1990"),
+      ent("b", "BP Exploration (Beta) Limited", "GB", "1990"),
+    ])).toHaveLength(0);
+  });
+
+  it("flags two same-name entities that reconcileBods kept separate (different LEIs)", () => {
+    const lei1 = "529900T8BM49AURSDO55";
+    const lei2 = "213800LH1BZH3DI6G760";
+    const { statements } = reconcileBods([
+      {
+        statementId: "x", recordType: "entity",
+        recordDetails: { name: "Globex Holdings", jurisdiction: { code: "FR" }, foundingDate: "2001",
+          identifiers: [{ scheme: "XI-LEI", id: lei1 }] },
+        source: { description: "GLEIF" },
+      },
+      {
+        statementId: "y", recordType: "entity",
+        recordDetails: { name: "GLOBEX HOLDINGS", jurisdiction: { code: "FR" }, foundingDate: "2001",
+          identifiers: [{ scheme: "XI-LEI", id: lei2 }] },
+        source: { description: "OpenCorporates" },
+      },
+    ]);
+    // different LEIs -> two canonical nodes; same name+jurisdiction+year -> a candidate
+    expect(statements.filter((s) => s.recordType === "entity")).toHaveLength(2);
+    expect(possiblySameAs(statements)).toHaveLength(1);
   });
 });

--- a/frontend/src/lib/reconcile.ts
+++ b/frontend/src/lib/reconcile.ts
@@ -61,7 +61,17 @@ function identKeys(s: Stmt): string[] {
     }
     const scheme = String(i.scheme ?? "?").trim().toUpperCase();
     keys.push(`${scheme}:${val}`);
-    if (jur && (scheme === "" || scheme.startsWith(`${jur}-`)) && !val.includes("/")) {
+    // Jurisdiction+bare-value key bridges the same registration number under
+    // different scheme labels (CVR / COA / empty). Exclude VAT schemes — a VAT
+    // number coincidentally equal to a different entity's company number in the
+    // same jurisdiction must not merge them; VAT still merges scheme-scoped
+    // (`<JUR>-VAT:value` / `XI-VAT:value`), since a shared VAT means same entity.
+    if (
+      jur &&
+      (scheme === "" || scheme.startsWith(`${jur}-`)) &&
+      !scheme.includes("VAT") &&
+      !val.includes("/")
+    ) {
       keys.push(`JUR:${jur}:${val}`);
     }
   }
@@ -125,12 +135,14 @@ export function reconcileBods(statements: Stmt[]): ReconcileResult {
     let name = "";
     let jurisdiction: unknown;
     let entityType: unknown;
+    let foundingDate = "";
     for (const m of members) {
       remap[m] = canonicalId;
       const d = rd(byId.get(m)!);
       if (!name && d.name) name = d.name as string;
       if (!jurisdiction && d.jurisdiction) jurisdiction = d.jurisdiction;
       if (!entityType && d.entityType) entityType = d.entityType;
+      if (!foundingDate && d.foundingDate) foundingDate = d.foundingDate as string;
       for (const i of (d.identifiers ?? []) as Stmt[]) {
         const k = `${i.scheme}|${i.id}`;
         if (!seenIdent.has(k)) {
@@ -151,6 +163,7 @@ export function reconcileBods(statements: Stmt[]): ReconcileResult {
         name: name || canonicalId,
         identifiers: mergedIdents,
         ...(jurisdiction ? { jurisdiction } : {}),
+        ...(foundingDate ? { foundingDate } : {}),
       },
       source: byId.get(members[0])!.source ?? {},
       _sources: [...sources],
@@ -201,6 +214,94 @@ export function reconcileBods(statements: Stmt[]): ReconcileResult {
   }
 
   return { statements: out, remap };
+}
+
+// ---------------------------------------------------------------------------
+// POSSIBLY_SAME_AS — name-only "likely same" candidates (human-reviewed)
+//
+// Run AFTER reconcileBods on the reconciled nodes. Identifier-based merging has
+// already collapsed the certain matches; this surfaces the residual: distinct
+// nodes that share an exact normalised name + jurisdiction but no shared
+// identifier. The Splink spike (see Notion) showed this rule beats both fuzzy
+// matching and a trained probabilistic model on OpenCheck's data (F1 0.95).
+//
+// These are **suggestions for a human**, rendered as a dashed "likely same"
+// edge — never a silent merge (a false merge is a compliance liability). A
+// founding-date tiebreaker rejects the same-name/different-entity case (e.g.
+// distinct same-named subsidiaries incorporated in different years); address is
+// deliberately NOT used — its cross-source formatting is too noisy to require.
+// ---------------------------------------------------------------------------
+
+export interface SameAsCandidate {
+  /** statementIds (canonical node ids after reconcileBods) of the two nodes. */
+  a: string;
+  b: string;
+  /** Why they're flagged — drives the edge tooltip. */
+  reason: string;
+}
+
+function normName(s: string): string {
+  return s
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function jurOf(s: Stmt): string {
+  return String(((rd(s).jurisdiction as Stmt | undefined)?.code as string | undefined) ?? "")
+    .trim()
+    .toUpperCase()
+    .split("-")[0];
+}
+
+function foundingYear(s: Stmt): string | null {
+  const m = String(rd(s).foundingDate ?? "").trim().match(/^(\d{4})/);
+  return m ? m[1] : null;
+}
+
+/** Compatible unless BOTH founding years are present and differ. */
+function dateCompatible(a: Stmt, b: Stmt): boolean {
+  const ya = foundingYear(a);
+  const yb = foundingYear(b);
+  return !(ya && yb && ya !== yb);
+}
+
+/** Candidate "likely same" pairs among the reconciled entity nodes: exact
+ *  normalised name + same jurisdiction, no shared identifier (already merged if
+ *  they did), passing the founding-date tiebreaker. */
+export function possiblySameAs(statements: Stmt[]): SameAsCandidate[] {
+  const ents = (statements ?? []).filter((s) => s.recordType === "entity" && s.statementId);
+  const groups = new Map<string, Stmt[]>();
+  for (const s of ents) {
+    const nm = normName(String(rd(s).name ?? ""));
+    const jur = jurOf(s);
+    if (!nm || !jur) continue; // both required — name alone over-merges
+    const key = `${nm}|${jur}`;
+    const g = groups.get(key) ?? [];
+    g.push(s);
+    groups.set(key, g);
+  }
+  const out: SameAsCandidate[] = [];
+  for (const group of groups.values()) {
+    if (group.length < 2) continue;
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        const a = group[i];
+        const b = group[j];
+        if (a.statementId === b.statementId) continue;
+        if (!dateCompatible(a, b)) continue; // different incorporation year → different entity
+        out.push({
+          a: a.statementId as string,
+          b: b.statementId as string,
+          reason: "same name + jurisdiction",
+        });
+      }
+    }
+  }
+  return out;
 }
 
 /** Apply an id remap to risk signals so their evidence statement-ids follow the


### PR DESCRIPTION
…viewed)

Implements the Splink-spike outcome — exact normalised-name + jurisdiction with a founding-date tiebreaker — as the no-shared-identifier entity-dedup residual, in both layers (same rule, mirrored):

Frontend (FullCheck graph):
- reconcile.ts: possiblySameAs() + carry foundingDate onto canonical nodes; VAT guard on the jurisdiction+bare-number merge key
- bodsGraph.ts / BODSGraph.tsx: 'possiblySame' dashed, undirected 'likely same' edge category (render-only overlay; not in the ownership hierarchy/tree/frontier)
- BodsGraphExplorer: inject edges (fullCheck) + caption; dedupe the frontier by canonical id so the 'Add next layer N' count matches visible nodes

Backend (report/API):
- reconcile.py: possibly_same_entities(bods) — same rule on the assembled bundle, excluding pairs already linked by a shared identifier
- routers/lookup.py: new possibly_same_entities field on the lookup/report response

Suggestions for human review, never silent merges (a false merge is a compliance liability). Deterministic identifier matching unchanged. 2191 backend tests pass; reconcile.test.ts + test_reconcile.py cover the rule, tiebreaker, VAT guard, and identifier-linked exclusion.